### PR TITLE
Add params to renderWidget function

### DIFF
--- a/blockinstagram.php
+++ b/blockinstagram.php
@@ -146,7 +146,7 @@ class BlockInstagram extends Module implements WidgetInterface
 
     public function hookDisplayHome($params)
     {
-        return $this->renderWidget('home');
+        return $this->renderWidget('home', $params);
     }
 
     public function renderWidget($hookName, array $configuration)


### PR DESCRIPTION
Otherwise it causes an error 'Too few arguments'.